### PR TITLE
Fixes PropTypes warnings from react 15 (deprecated)

### DIFF
--- a/DateTime.js
+++ b/DateTime.js
@@ -6,10 +6,10 @@ var assign = require('object-assign'),
 	MonthsView = require('./src/MonthsView'),
 	YearsView = require('./src/YearsView'),
 	TimeView = require('./src/TimeView'),
-	moment = require('moment')
+	moment = require('moment'),
+	TYPES = require('prop-types')
 ;
 
-var TYPES = React.PropTypes;
 var Datetime = React.createClass({
 	mixins: [
 		require('./src/onClickOutside')

--- a/package.json
+++ b/package.json
@@ -49,6 +49,7 @@
   },
   "dependencies": {
     "object-assign": "^3.0.0",
+    "prop-types": "^0.2.0",
     "react-onclickoutside": "^4.1.0"
   }
 }


### PR DESCRIPTION
https://facebook.github.io/react/warnings/dont-call-proptypes.html

Uses external library https://github.com/aackerman/PropTypes
